### PR TITLE
Corrected spelling for saveUninitialized

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,7 +37,7 @@ app.use(express.static(path.join(__dirname, 'public')));
 //Express session
 app.use(session({
   secret: 'secret',
-    //saveUnitialized: true,
+    //saveUninitialized: true,
     //resave: true
 }));
 


### PR DESCRIPTION
Came across ur repo studying some node, tried to run it, got the errors : express-session deprecated undefined resave option; provide resave option... 
Noticed ur saveUninitialized cookie variable was mispelled. Now i get no errors, but i dont see it running on localhost:3000 . 
Still cant get the code to run when i do node app.js tho. 
But goodluck on your project :P